### PR TITLE
cli.rb patch

### DIFF
--- a/cli.rb
+++ b/cli.rb
@@ -22,7 +22,16 @@
 # License along with this program. If not, see
 # <http://www.gnu.org/licenses/>.
 require 'multi_json'
-require_relative 'lib/xa/rules/parse'
+require_relative 'lib/xa/rules/parse/content'
 
-include XA::Rules::Parse
-IO.write(ARGV[1], MultiJson.dump(parse(IO.read(ARGV[0])), pretty: true))
+include XA::Rules::Parse::Content
+
+IO.write(
+    ARGV[1], 
+    MultiJson.dump(
+        parse_rule(
+            IO.read(
+                ARGV[0]
+            )
+        ),
+        pretty: true))

--- a/cli.rb
+++ b/cli.rb
@@ -27,13 +27,21 @@ require_relative 'lib/xa/rules/parse/content'
 
 include XA::Rules::Parse::Content
 
-input_file = ARGV[0]
-output_file = (ARGV[1] != nil) ? ARGV[1] : "#{input_file}.json"
+def run
+    input_file = ARGV[0]
+    output_file = (ARGV[1] != nil) ? ARGV[1] : "#{input_file}.json"
 
-if input_file.end_with?(".rule")
-    IO.write(output_file, MultiJson.dump(parse_rule(IO.read(input_file)), pretty: true))
-elsif input_file.end_with?(".table")
-    IO.write(output_file, MultiJson.dump(parse_table(IO.read(input_file)), pretty: true))
+    if input_file.end_with?(".rule")
+        IO.write(output_file, MultiJson.dump(parse_rule(IO.read(input_file)), pretty: true))
+    elsif input_file.end_with?(".table")
+        IO.write(output_file, MultiJson.dump(parse_table(IO.read(input_file)), pretty: true))
+    else
+        raise 'File type not *.rule or *.table'
+    end
+end
+
+if ARGV[0] == nil
+    raise 'Please provide a .rule or .table file to parse'
 else
-    raise 'File type not *.rule or *.table'
+    run
 end

--- a/cli.rb
+++ b/cli.rb
@@ -21,17 +21,13 @@
 # You should have received a copy of the GNU Affero General Public
 # License along with this program. If not, see
 # <http://www.gnu.org/licenses/>.
+
 require 'multi_json'
 require_relative 'lib/xa/rules/parse/content'
 
 include XA::Rules::Parse::Content
 
-IO.write(
-    ARGV[1], 
-    MultiJson.dump(
-        parse_rule(
-            IO.read(
-                ARGV[0]
-            )
-        ),
-        pretty: true))
+input_file = ARGV[0]
+output_file = (ARGV[1] != nil) ? ARGV[1] : "#{input_file}.json"
+
+IO.write(output_file, MultiJson.dump(parse_rule(IO.read(input_file)), pretty: true))

--- a/cli.rb
+++ b/cli.rb
@@ -30,4 +30,10 @@ include XA::Rules::Parse::Content
 input_file = ARGV[0]
 output_file = (ARGV[1] != nil) ? ARGV[1] : "#{input_file}.json"
 
-IO.write(output_file, MultiJson.dump(parse_rule(IO.read(input_file)), pretty: true))
+if input_file.end_with?(".rule")
+    IO.write(output_file, MultiJson.dump(parse_rule(IO.read(input_file)), pretty: true))
+elsif input_file.end_with?(".table")
+    IO.write(output_file, MultiJson.dump(parse_table(IO.read(input_file)), pretty: true))
+else
+    raise 'File type not *.rule or *.table'
+end


### PR DESCRIPTION
Adapted `cli.rb` so it works on my personal windows and linux environments.

- Infer second argument if only .rule/.table is passed
- Use rule/table parser depending on file extension
- Warn if filetype is wrong, or input not provided