### PR TITLE
cli.rb patch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,9 @@ capybara-*.html
 rerun.txt
 pickle-email-*.html
 
+/test-runs/
+/.idea/
+
 # TODO Comment out these rules if you are OK with secrets being uploaded to the repo
 config/initializers/secret_token.rb
 config/secrets.yml

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 sudo: required
 language: ruby
 rvm:
-- 2.4.2
+- 2.7.0
 script:
 - "bundle exec rspec"
 notifications:

--- a/cli.rb
+++ b/cli.rb
@@ -22,7 +22,16 @@
 # License along with this program. If not, see
 # <http://www.gnu.org/licenses/>.
 require 'multi_json'
-require_relative 'lib/xa/rules/parse'
+require_relative 'lib/xa/rules/parse/content'
 
-include XA::Rules::Parse
-IO.write(ARGV[1], MultiJson.dump(parse(IO.read(ARGV[0])), pretty: true))
+include XA::Rules::Parse::Content
+
+IO.write(
+    ARGV[1], 
+    MultiJson.dump(
+        parse_rule(
+            IO.read(
+                ARGV[0]
+            )
+        ),
+        pretty: true))

--- a/cli.rb
+++ b/cli.rb
@@ -27,13 +27,21 @@ require_relative 'lib/xa/rules/parse/content'
 
 include XA::Rules::Parse::Content
 
-input_file = ARGV[0]
-output_file = (ARGV[1] != nil) ? ARGV[1] : "#{input_file}.json"
+def run
+    input_file = ARGV[0]
+    output_file = (ARGV[1] != nil) ? ARGV[1] : "#{input_file}.json"
 
-if input_file.end_with?(".rule")
-    IO.write(output_file, MultiJson.dump(parse_rule(IO.read(input_file)), pretty: true))
-elsif input_file.end_with?(".table")
-    IO.write(output_file, MultiJson.dump(parse_table(IO.read(input_file)), pretty: true))
+    if input_file.end_with?(".rule")
+        IO.write(output_file, MultiJson.dump(parse_rule(IO.read(input_file)), pretty: true))
+    elsif input_file.end_with?(".table")
+        IO.write(output_file, MultiJson.dump(parse_table(IO.read(input_file)), pretty: true))
+    else
+        raise 'File type not *.rule or *.table'
+    end
+end
+
+if ARGV[0] == nil
+    raise 'Please provide a .rule or .table file to parse'
 else
-    raise 'File type not *.rule or *.table'
+    run
 end

--- a/cli.rb
+++ b/cli.rb
@@ -21,17 +21,13 @@
 # You should have received a copy of the GNU Affero General Public
 # License along with this program. If not, see
 # <http://www.gnu.org/licenses/>.
+
 require 'multi_json'
 require_relative 'lib/xa/rules/parse/content'
 
 include XA::Rules::Parse::Content
 
-IO.write(
-    ARGV[1], 
-    MultiJson.dump(
-        parse_rule(
-            IO.read(
-                ARGV[0]
-            )
-        ),
-        pretty: true))
+input_file = ARGV[0]
+output_file = (ARGV[1] != nil) ? ARGV[1] : "#{input_file}.json"
+
+IO.write(output_file, MultiJson.dump(parse_rule(IO.read(input_file)), pretty: true))

--- a/cli.rb
+++ b/cli.rb
@@ -27,10 +27,14 @@ require_relative 'lib/xa/rules/parse/content'
 
 include XA::Rules::Parse::Content
 
-def run
-    input_file = ARGV[0]
-    output_file = (ARGV[1] != nil) ? ARGV[1] : "#{input_file}.json"
+# Determines if file is a rule or table, and runs relevant library method.
+def parse_file(input_file, output_file)
 
+    puts "Parsing #{input_file}"
+
+    if output_file == nil
+        output_file = "#{input_file}.json"
+    end
     if input_file.end_with?(".rule")
         IO.write(output_file, MultiJson.dump(parse_rule(IO.read(input_file)), pretty: true))
     elsif input_file.end_with?(".table")
@@ -40,8 +44,21 @@ def run
     end
 end
 
-if ARGV[0] == nil
-    raise 'Please provide a .rule or .table file to parse'
-else
-    run
+# Executes on program start. For each file in a folder, or a single file, runs parse_file
+def cli_run
+    if ARGV[0] == nil
+        raise 'Please provide a .rule or .table file to parse'
+    elsif File.directory?(ARGV[0])
+        Dir.foreach(ARGV[0]) do |name|
+            file = File.join(ARGV[0], name)
+            if file.end_with?(".table") || file.end_with?(".rule")
+                parse_file(file, nil)
+            end
+        end
+    else
+        parse_file(ARGV[0], ARGV[1])
+    end
 end
+
+# Execute immediately
+cli_run

--- a/cli.rb
+++ b/cli.rb
@@ -30,4 +30,10 @@ include XA::Rules::Parse::Content
 input_file = ARGV[0]
 output_file = (ARGV[1] != nil) ? ARGV[1] : "#{input_file}.json"
 
-IO.write(output_file, MultiJson.dump(parse_rule(IO.read(input_file)), pretty: true))
+if input_file.end_with?(".rule")
+    IO.write(output_file, MultiJson.dump(parse_rule(IO.read(input_file)), pretty: true))
+elsif input_file.end_with?(".table")
+    IO.write(output_file, MultiJson.dump(parse_table(IO.read(input_file)), pretty: true))
+else
+    raise 'File type not *.rule or *.table'
+end


### PR DESCRIPTION
Adapted `cli.rb` so it works on my personal windows and linux environments.

- Infer second argument if only .rule/.table file location is passed.
- Use rule/table parser depending on file extension.
- Throw errors if file-type is incorrect or missing
- Fix travis builds by bumping RVM target
- Allow a directory of .rule/.table files to be passed as first argument